### PR TITLE
Tweak cache-update test

### DIFF
--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -69,6 +69,8 @@ template <typename T>
 const RigidTransform<T>& QueryObject<T>::GetPoseInWorld(
     GeometryId geometry_id) const {
   ThrowIfNotCallable();
+  FullPoseUpdate();
+
   if (inspector_.IsDeformableGeometry(geometry_id)) {
     throw std::logic_error(
         fmt::format("{} is not allowed to be called on deformable geometries. "
@@ -79,7 +81,6 @@ const RigidTransform<T>& QueryObject<T>::GetPoseInWorld(
                     __func__));
   }
 
-  FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.get_pose_in_world(geometry_id);
 }


### PR DESCRIPTION
1. Respells out the cache update is poked.
2. Adds *every* query with a clear statement of whether it should update both caches or just one.
3. Incidental tweak to one method such that the cache update comes before any thrown exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xuchenhan-tri/drake/12)
<!-- Reviewable:end -->
